### PR TITLE
fix: build failure with musl by replacing NULL with integer in msghdr…

### DIFF
--- a/netifaces/_netifaces.c
+++ b/netifaces/_netifaces.c
@@ -2003,7 +2003,7 @@ gateways (PyObject *self)
         sizeof(sanl_from),
         &iov,
         1,
-        NULL,
+        0,
         0,
         0
       };


### PR DESCRIPTION
this patch fixes a build error when compiling netifaces-plus on alpine (musl-based systems) with Python 3.12. The error occurred due to the use of `NULL` in an integer field (`msghdr.__pad1`) during struct initialization, which causes a type mismatch under strict compiler flags (-Wint-conversion).

replacing `NULL` with `0` resolves the issue and allows the package to compile successfully on musl-based systems.

tested on:
- Alpine 3.22
- Python 3.12.11
- gcc (alpine musl libc v1.2.5) 14.2.0

fixes: #9 

<img width="1646" height="559" alt="image" src="https://github.com/user-attachments/assets/246db30a-586c-4673-8780-d46baa0ba3b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Linuxシステムでのネットワークゲートウェイ情報の取得時に、内部処理の安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->